### PR TITLE
Remove mentions of autofix being in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # `gh-autofix`
 
-_Code scanning autofix is currently in [public beta](https://github.blog/2024-03-20-found-means-fixed-introducing-code-scanning-autofix-powered-by-github-copilot-and-codeql/)_
-
 A `gh` CLI extension allowing users to easily edit autofix suggestions in their local repository checkout.
 
 ## Installation
@@ -21,8 +19,6 @@ gh autofix --help
 ## Background
 
 The `gh-autofix` extension for the `gh` CLI allows users to view and apply autofix suggestions made on their pull requests. See the [code scanning autofix documentation](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-autofix-for-codeql-code-scanning) for more information.
-
-Code scanning autofix is currently in public beta, see the [announcement post for more details](https://github.blog/2024-03-20-found-means-fixed-introducing-code-scanning-autofix-powered-by-github-copilot-and-codeql/).
 
 ## Requirements
 


### PR DESCRIPTION
⚠️ Only merge on @AlonaHlobina's approval

As part of autofix officially launching we need to remove the mentions of it being in beta from the documentation.
See issue: https://github.com/github/code-scanning/issues/14865
